### PR TITLE
Upgrade Spring Boot and OAuth2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
 		maven { url "https://repo.spring.io/plugins-release" }
 	}
 	dependencies {
-		classpath("org.springframework.boot:spring-boot-gradle-plugin:1.2.5.RELEASE")
+		classpath("org.springframework.boot:spring-boot-gradle-plugin:1.2.7.RELEASE")
 	}
 }
 
@@ -28,8 +28,7 @@ dependencies {
 	compile("org.springframework.boot:spring-boot-starter-web")
 	compile("org.springframework.boot:spring-boot-starter-security")
 	compile("org.springframework.boot:spring-boot-starter-data-jpa")
-	compile("org.springframework.security.oauth:spring-security-oauth2:2.0.7.RELEASE")
-	compile("com.fasterxml.jackson.core:jackson-databind")
+	compile("org.springframework.security.oauth:spring-security-oauth2:2.0.8.RELEASE")
 	compile("org.hsqldb:hsqldb")
 	providedRuntime("org.springframework.boot:spring-boot-starter-tomcat")
 	testCompile("org.springframework.boot:spring-boot-starter-test")

--- a/pom.xml
+++ b/pom.xml
@@ -11,11 +11,12 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>1.2.5.RELEASE</version>
+		<version>1.2.7.RELEASE</version>
 	</parent>
 
 	<properties>
-		<spring-security-oauth2.version>2.0.7.RELEASE</spring-security-oauth2.version>
+		<spring-security-oauth2.version>2.0.8.RELEASE</spring-security-oauth2.version>
+        <java.version>1.8</java.version>
 	</properties>
 
 	<dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -38,10 +38,6 @@
 			<version>${spring-security-oauth2.version}</version>
 		</dependency>
 		<dependency>
-			<groupId>com.fasterxml.jackson.core</groupId>
-			<artifactId>jackson-databind</artifactId>
-		</dependency>
-		<dependency>
 			<groupId>org.hsqldb</groupId>
 			<artifactId>hsqldb</artifactId>
 		</dependency>

--- a/src/test/java/hello/GreetingControllerTest.java
+++ b/src/test/java/hello/GreetingControllerTest.java
@@ -16,16 +16,26 @@
 
 package hello;
 
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.MockitoAnnotations;
-
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.SpringApplicationConfiguration;
 import org.springframework.http.MediaType;
 import org.springframework.security.web.FilterChainProxy;
-import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.web.WebAppConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
@@ -33,17 +43,12 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.util.Base64Utils;
 import org.springframework.web.context.WebApplicationContext;
 
-import static org.hamcrest.Matchers.*;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
-
 /**
  * @author Roy Clarkson
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 @WebAppConfiguration
-@ContextConfiguration(classes = Application.class)
+@SpringApplicationConfiguration(classes = Application.class)
 public class GreetingControllerTest {
 
 	@Autowired
@@ -61,8 +66,7 @@ public class GreetingControllerTest {
 	public void setUp() {
 		MockitoAnnotations.initMocks(this);
 		mvc = MockMvcBuilders.webAppContextSetup(context)
-				.addFilter(springSecurityFilterChain)
-				.build();
+				.addFilter(springSecurityFilterChain).build();
 	}
 
 	@Test
@@ -76,7 +80,8 @@ public class GreetingControllerTest {
 	}
 
 	private String getAccessToken(String username, String password) throws Exception {
-		String authorization = "Basic " + new String(Base64Utils.encode("clientapp:123456".getBytes()));
+		String authorization = "Basic "
+				+ new String(Base64Utils.encode("clientapp:123456".getBytes()));
 		String contentType = MediaType.APPLICATION_JSON + ";charset=UTF-8";
 
 		// @formatter:off

--- a/src/test/java/hello/HomeControllerTest.java
+++ b/src/test/java/hello/HomeControllerTest.java
@@ -26,9 +26,9 @@ import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.MockitoAnnotations;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.SpringApplicationConfiguration;
 import org.springframework.http.MediaType;
 import org.springframework.security.web.FilterChainProxy;
-import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.web.WebAppConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
@@ -40,7 +40,7 @@ import org.springframework.web.context.WebApplicationContext;
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 @WebAppConfiguration
-@ContextConfiguration(classes = Application.class)
+@SpringApplicationConfiguration(classes = Application.class)
 public class HomeControllerTest {
 
 	@Autowired
@@ -58,8 +58,7 @@ public class HomeControllerTest {
 	public void setUp() {
 		MockitoAnnotations.initMocks(this);
 		mvc = MockMvcBuilders.webAppContextSetup(context)
-				.addFilter(springSecurityFilterChain)
-				.build();
+				.addFilter(springSecurityFilterChain).build();
 	}
 
 	@Test


### PR DESCRIPTION
Boot 1.2.7 and OAuth2 2.0.8 are now released so this change updates
the dependencies.

Also reverts the java version in the pom.xml because Eclipse users
will otherwise find that the project defaults to Java 6 and breaks
because of a mismatch with the Web 3.1 profile.